### PR TITLE
More accurate look angles

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Calc GST given year, month, day, hour, minute and second
 #### func  JDay
 
 ```go
-func JDay(year, mon, day, hr, min, sec int) float64
+func JDay(year, mon, day, hr, min int, sec float64) (float64, float64)
 ```
 Calc julian date given year, month, day, hour, minute and second the julian date
 is defined by each elapsed day since noon, jan 1, 4713 bc.
@@ -53,7 +53,7 @@ is defined by each elapsed day since noon, jan 1, 4713 bc.
 #### func  Propagate
 
 ```go
-func Propagate(sat Satellite, year int, month int, day, hours, minutes, seconds int) (position, velocity Vector3)
+func Propagate(sat Satellite, jDay, jF float64) (position, velocity Vector3)
 ```
 Calculates position and velocity vectors for given time
 
@@ -96,7 +96,7 @@ Holds an azimuth, elevation and range
 #### func  ECIToLookAngles
 
 ```go
-func ECIToLookAngles(eciSat Vector3, obsCoords LatLong, obsAlt, jday float64) (lookAngles LookAngles)
+func ECIToLookAngles(eciSat Vector3, obsCoords LatLong, obsAlt, jday float64, gravConst GravConst) (lookAngles LookAngles)
 ```
 Calculate look angles for given satellite position and observer position obsAlt
 in km Reference: http://celestrak.com/columns/v02n02/

--- a/gravity.go
+++ b/gravity.go
@@ -7,7 +7,7 @@ import (
 
 // Holds variables that are dependent upon selected gravity model
 type GravConst struct {
-	mu, radiusearthkm, xke, tumin, j2, j3, j4, j3oj2 float64
+	mu, radiusearthkm, xke, tumin, j2, j3, j4, j3oj2, f float64
 }
 
 // Returns a GravConst with correct information on requested model provided through the name parameter
@@ -22,6 +22,7 @@ func getGravConst(name string) (grav GravConst) {
 		grav.j3 = -0.00000253881
 		grav.j4 = -0.00000165597
 		grav.j3oj2 = grav.j3 / grav.j2
+		grav.f = 1 / 298.26
 	case "wgs72":
 		grav.mu = 398600.8
 		grav.radiusearthkm = 6378.135
@@ -31,6 +32,7 @@ func getGravConst(name string) (grav GravConst) {
 		grav.j3 = -0.00000253881
 		grav.j4 = -0.00000165597
 		grav.j3oj2 = grav.j3 / grav.j2
+		grav.f = 1 / 298.26
 	case "wgs84":
 		grav.mu = 398600.5
 		grav.radiusearthkm = 6378.137
@@ -40,6 +42,7 @@ func getGravConst(name string) (grav GravConst) {
 		grav.j3 = -0.00000253215306
 		grav.j4 = -0.00000161098761
 		grav.j3oj2 = grav.j3 / grav.j2
+		grav.f = 1 / 298.257223563
 	default:
 		log.Fatal(name, "is not a valid gravity model")
 	}

--- a/helpers.go
+++ b/helpers.go
@@ -83,9 +83,9 @@ func TLEToSat(line1, line2 string, gravconst string) Satellite {
 
 	mon, day, hr, min, sec := days2mdhms(year, sat.epochdays)
 
-	sat.jdsatepoch = JDay(int(year), int(mon), int(day), int(hr), int(min), int(sec))
+	sat.jdsatepoch, sat.jdsatepochF = JDay(int(year), int(mon), int(day), int(hr), int(min), sec)
 
-	sgp4init(&opsmode, sat.jdsatepoch-2433281.5, &sat)
+	sgp4init(&opsmode, sat.jdsatepoch+sat.jdsatepochF-2433281.5, &sat)
 
 	return sat
 }

--- a/satellite.go
+++ b/satellite.go
@@ -11,9 +11,10 @@ type Satellite struct {
 	ErrorStr   string
 	whichconst GravConst
 
-	epochyr    int64
-	epochdays  float64
-	jdsatepoch float64
+	epochyr     int64
+	epochdays   float64
+	jdsatepoch  float64
+	jdsatepochF float64
 
 	ndot  float64
 	nddot float64

--- a/satellite_suite_test.go
+++ b/satellite_suite_test.go
@@ -7,6 +7,7 @@ import (
 	"strconv"
 	"strings"
 	"testing"
+	"time"
 )
 
 func TestSatellite(t *testing.T) {
@@ -20,6 +21,31 @@ type Result struct {
 }
 
 var _ = Describe("go-satellite", func() {
+
+	Describe("LookAngles", func() {
+
+		It("should return correct observer look angles for given ISS#22825 at 2020-05-23T20:23:37", func() {
+			sat := TLEToSat("1 25544U 98067A   20140.34419374 -.00000374  00000-0  13653-5 0  9990", "2 25544  51.6433 131.2277 0001338 330.3524 173.1622 15.49372617227549", "wgs72")
+
+			time := time.Date(2020, 5, 23, 20, 23, 37, 0, time.UTC)
+			year, month, day := time.Date()
+			hour, min, sec := time.Clock()
+
+			jDay, jF := JDay(year, int(month), day, hour, min, float64(sec))
+			pos, _ := Propagate(sat, jDay, jF)
+
+			latLong := LatLong{
+				Latitude:  DEG2RAD * 55.6167,
+				Longitude: DEG2RAD * 12.6500}
+			alt := 0.005
+
+			angles := ECIToLookAngles(pos, latLong, alt, jDay+jF, sat.whichconst)
+
+			Expect(angles.El * RAD2DEG).To(Equal(42.06164214709452))
+			Expect(angles.Az * RAD2DEG).To(Equal(181.2902281625632))
+		})
+	})
+
 	Describe("ParseTLE", func() {
 		It("should return correctly parsed values for given ISS#25544", func() {
 			sat := ParseTLE("1 25544U 98067A   08264.51782528 -.00002182  00000-0 -11606-4 0  2927", "2 25544  51.6416 247.4627 0006703 130.5360 325.0288 15.72125391563537", "wgs84")
@@ -221,7 +247,7 @@ var _ = Describe("go-satellite", func() {
 			PropagationTestCase{
 				line1: "1 23599U 95029B   06171.76535463  .00085586  12891-6  12956-2 0  2905",
 				line2: "2 23599   6.9327   0.2849 5782022 274.4436  25.2425  4.47796565123555",
-				grav: "wgs72",
+				grav:  "wgs72",
 				testData: `0.00000000 9892.63794341 35.76144969 -1.08228838 3.556643237 6.456009375 0.783610890       
 20.00000000 11931.95642997 7340.74973750 886.46365987 0.308329116 5.532328972 0.672887281
 40.00000000 11321.71039205 13222.84749156 1602.40119049 -1.151973982 4.285810871 0.521919425

--- a/sgp4.go
+++ b/sgp4.go
@@ -292,10 +292,9 @@ func initl(satn int64, grav GravConst, ecco, epoch, inclo, noIn float64, methodI
 }
 
 // Calculates position and velocity vectors for given time
-func Propagate(sat Satellite, year int, month int, day, hours, minutes, seconds int) (position, velocity Vector3) {
-	j := JDay(year, month, day, hours, minutes, seconds)
-	m := (j - sat.jdsatepoch) * 1440
-	return sgp4(&sat, m)
+func Propagate(sat Satellite, jDay, jF float64) (position, velocity Vector3) {
+	tsince := (jDay-sat.jdsatepoch)*1440 + (jF-sat.jdsatepochF)*1440
+	return sgp4(&sat, tsince)
 }
 
 // this procedure is the sgp4 prediction model from space command. this is an updated and combined version of sgp4 and sdp4, which were originally published separately in spacetrack report #3. this version follows the methodology from the aiaa paper (2006) describing the history and development of the code.


### PR DESCRIPTION
There were some inaccuracies in time conversions and angle calculations that leaded in loosing several seconds on AOS and LOS times for ground station. Some of these changes breaks backward compatibility.

As a reference I used gPredict, pyorbital and [sgp4](https://pypi.org/project/sgp4)